### PR TITLE
Fixing the Creation DB if it does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,49 @@ Routes -> `where we handle our app routes like the 'authRoutes' has login route 
 
 config -> `that where we have the configration for our database`
 
+Pre-Requisites:
+Before running the code, ensure that the PostgreSQL user has been created and configured with appropriate permissions. Execute the following commands in your terminal:
+
+Switch to the postgres user:
+```bash
+sudo -i -u postgres
+```
+
+Create a new PostgreSQL user (e.g., postgres):
+```bash
+createuser --interactive
+Enter the role name: postgres
+Is the new role a superuser? (n)
+Can the role create databases? (y)
+Can the role create more roles? (n)
+```
+
+Switch to the PostgreSQL command-line interface:
+```bash
+psql
+```
+
+Set the password for the postgres user:
+```sql
+ALTER USER postgres WITH PASSWORD 'the password in the .env file';
+```
+
+Grant all privileges on the target database to the postgres user:
+```sql
+GRANT ALL PRIVILEGES ON DATABASE learning_system TO postgres;
+```
+
+Exit the PostgreSQL CLI:
+```sql
+\q
+```
+
+Exit the postgres user session:
+```bash
+exit
+```
+
+Finally, run your server.
 
 ### you can use seeders to have a quick access to some default data in the database
 

--- a/Server/.env
+++ b/Server/.env
@@ -1,5 +1,3 @@
-DATABASE_URL="postgres://postgres:12345@localhost:5432/learning_system"
-
 PORT= 8000
 
 DB_USERNAME = postgres

--- a/Server/.env
+++ b/Server/.env
@@ -1,4 +1,4 @@
-DATABASE_URL="postgres://postgres:12345@localhost:5432/test"
+DATABASE_URL="postgres://postgres:12345@localhost:5432/learning_system"
 
 PORT= 8000
 

--- a/Server/config/config.js
+++ b/Server/config/config.js
@@ -18,7 +18,7 @@ const parseDatabaseUrl = (url) => {
   }
 };
 
-const config = process.env.DATABASE_URL ? parseDatabaseUrl(process.env.DATABASE_URL) : {
+const config = {
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,

--- a/Server/config/config.js
+++ b/Server/config/config.js
@@ -1,12 +1,34 @@
 require('dotenv').config();
 
+// Function to parse DATABASE_URL
+const parseDatabaseUrl = (url) => {
+  const regex = /postgres:\/\/([^:]+):([^@]+)@([^:]+):(\d+)\/(.+)/;
+  const matches = url.match(regex);
+
+  if (matches) {
+    return {
+      username: matches[1],
+      password: matches[2],
+      host: matches[3],
+      port: parseInt(matches[4], 10),
+      database: matches[5]
+    };
+  } else {
+    throw new Error('Invalid DATABASE_URL format');
+  }
+};
+
+const config = process.env.DATABASE_URL ? parseDatabaseUrl(process.env.DATABASE_URL) : {
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT, 10),
+};
+
 module.exports = {
   development: {
-    username: process.env.DB_USERNAME,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    host: process.env.DB_HOST,
-    port:process.env.DB_PORT,
+    ...config,
     logging: false,
     define: {
       createdAt: "createdat",
@@ -15,11 +37,7 @@ module.exports = {
     dialect: 'postgres',
   },
   test: {
-    username: process.env.DB_USERNAME,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    host: process.env.DB_HOST,
-    port:process.env.DB_PORT,
+    ...config,
     define: {
       createdAt: "createdat",
       updatedAt: "updatedat"
@@ -27,11 +45,7 @@ module.exports = {
     dialect: 'postgres',
   },
   production: {
-    username: process.env.DB_USERNAME,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    host: process.env.DB_HOST,
-    port:process.env.DB_PORT,
+    ...config,
     define: {
       createdAt: "createdat",
       updatedAt: "updatedat"

--- a/Server/config/database.js
+++ b/Server/config/database.js
@@ -6,6 +6,70 @@ const dbConfig = config[environment];
 
 const sequelize = new Sequelize(dbConfig);
 
+/**
+Explanation of the Database Initialization Code
+
+Overview:
+Sequelize does not support direct database creation, so this process involves using a separate connection to the default PostgreSQL database for checking and creating the target database if necessary.
+
+So using a separate connection to create the database is more reliable, here is the process in detail:
+
+A temporary connection is established to the default PostgreSQL database (usually postgres).
+This connection is used to check if the target database (as specified in the .env file) exists.
+
+Executes a query to check if the target database exists.
+If the database does not exist, it creates the database.
+
+After ensuring the target database exists, the main Sequelize connection is established using the target database.
+
+That's it!
+*/
+async function validateDatabase() {
+    // Connect a separate connection to the default database
+    const tempSequelize = new Sequelize(process.env.DATABASE_URL, {
+        dialect: "postgres",
+        dialectOptions: {
+            ssl: {
+                require: true,
+                rejectUnauthorized: false,
+            },
+        },
+    });
+
+    try {
+        // Authenticate the temporary connection
+        await tempSequelize.authenticate();
+        console.log("Temporary connection has been established successfully.");
+
+        // Check if the database exists
+        const [results] = await tempSequelize.query(
+            `SELECT 1 FROM pg_database WHERE datname = '${dbConfig.database}'`
+        );
+
+        if (results.length === 0) {
+            // Create the database if it doesn't exist
+            await tempSequelize.query(
+                `CREATE DATABASE ${dbConfig.database}`
+            );
+            console.log(`Database ${dbConfig.database} created.`);
+        } else {
+            console.log(`Database ${dbConfig.database} already exists.`);
+        }
+    } catch (error) {
+        console.error("Unable to connect to the database:", error);
+    } finally {
+        // Close the temporary connection
+        await tempSequelize.close();
+    }
+
+    // Authenticate the main connection
+    try {
+        await sequelize.authenticate();
+        console.log("Connection has been established successfully.");
+    } catch (error) {
+        console.error("Unable to connect to the database:", error);
+    }
+}
 //! TODO: THIS PART WAS SUPPOSE FOR CREATING THE DATABASE IF IT DOESN'T EXIST BUT STILL DOESN'T WORK
 
 // async function validateDatabase() {
@@ -26,6 +90,6 @@ const sequelize = new Sequelize(dbConfig);
 //     });
 // }
 
-// validateDatabase();
+validateDatabase();
 
 module.exports = sequelize;

--- a/Server/config/database.js
+++ b/Server/config/database.js
@@ -6,40 +6,20 @@ const dbConfig = config[environment];
 
 const sequelize = new Sequelize(dbConfig);
 
-/**
-Explanation of the Database Initialization Code
 
-Overview:
-Sequelize does not support direct database creation, so this process involves using a separate connection to the default PostgreSQL database for checking and creating the target database if necessary.
-
-So using a separate connection to create the database is more reliable, here is the process in detail:
-
-A temporary connection is established to the default PostgreSQL database (usually postgres).
-This connection is used to check if the target database (as specified in the .env file) exists.
-
-Executes a query to check if the target database exists.
-If the database does not exist, it creates the database.
-
-After ensuring the target database exists, the main Sequelize connection is established using the target database.
-
-That's it!
-*/
 async function validateDatabase() {
     // Connect a separate connection to the default database
-    const tempSequelize = new Sequelize(process.env.DATABASE_URL, {
+    const tempSequelize = new Sequelize({
         dialect: "postgres",
         dialectOptions: {
-            ssl: {
-                require: true,
-                rejectUnauthorized: false,
-            },
         },
+        ...dbConfig,
+        database:null
     });
 
     try {
         // Authenticate the temporary connection
         await tempSequelize.authenticate();
-        console.log("Temporary connection has been established successfully.");
 
         // Check if the database exists
         const [results] = await tempSequelize.query(
@@ -52,8 +32,6 @@ async function validateDatabase() {
                 `CREATE DATABASE ${dbConfig.database}`
             );
             console.log(`Database ${dbConfig.database} created.`);
-        } else {
-            console.log(`Database ${dbConfig.database} already exists.`);
         }
     } catch (error) {
         console.error("Unable to connect to the database:", error);
@@ -70,26 +48,20 @@ async function validateDatabase() {
         console.error("Unable to connect to the database:", error);
     }
 }
-//! TODO: THIS PART WAS SUPPOSE FOR CREATING THE DATABASE IF IT DOESN'T EXIST BUT STILL DOESN'T WORK
 
-// async function validateDatabase() {
-//   // Test the connection and create the database if it doesn't exist
-//   await sequelize
-//     .authenticate()
-//     .then(async () => {
-//       console.log("Connection has been established successfully.");
-//       return await sequelize.query(
-//         `CREATE DATABASE IF NOT EXISTS ${dbConfig.database}`
-//       );
-//     })
-//     .then(() => {
-//       console.log("Database created or already exists.");
-//     })
-//     .catch((err) => {
-//       console.error("Unable to connect to the database:", err);
-//     });
-// }
+validateDatabase().then(() => {
+    // db connection
 
-validateDatabase();
+    sequelize
+    .sync({alter: true})
+    .then(() => {
+        console.log("Database synchronized");
+    })
+    .catch((err) => {
+        console.error("Unable to synchronize the database:", err);
+    });
+}).catch((err) => {
+    console.error("Unable to synchronize the database:", err);
+});
 
 module.exports = sequelize;

--- a/Server/server.js
+++ b/Server/server.js
@@ -1,10 +1,8 @@
 const express = require("express");
 const dotenv = require("dotenv");
-const { sequelize } = require("./Models");
+const morgan = require("morgan");
 
 const mainRoute = require("./Routes/index");
-const morgan = require("morgan");
-const { getAllUsers } = require("./Controllers/authController");
 const globalErrorHandler = require("./middlewares/globalErrorHandler");
 
 dotenv.config({ path: ".env" });
@@ -13,17 +11,6 @@ const app = express();
 
 app.use(express.json());
 app.use(morgan("dev"));
-
-// db connection
-
-sequelize
-  .sync({alter: true})
-  .then(() => {
-    console.log("Database synchronized");
-  })
-  .catch((err) => {
-    console.error("Unable to synchronize the database:", err);
-  });
 
 // main system route
 app.use("/api", mainRoute);


### PR DESCRIPTION
Explanation of the Database Initialization Code

Overview:
Sequelize does not support direct database creation, so this process involves using a separate connection to the default PostgreSQL database for checking and creating the target database if necessary.

So using a separate connection to create the database is more reliable, here is the process in detail:

A temporary connection is established to the default PostgreSQL database (usually postgres).
This connection is used to check if the target database (as specified in the .env file) exists.

Executes a query to check if the target database exists.
If the database does not exist, it creates the database.

After ensuring the target database exists, the main Sequelize connection is established using the target database.